### PR TITLE
Add full-featured temporal arena gameplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,16 +3,22 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Timelooper Prototype</title>
+    <title>Timelooper: Temporal Duel</title>
     <style>
       :root {
-        color-scheme: dark;
+        color-scheme: light;
+        --p1: #34d399;
+        --p2: #f87171;
+        --panel-bg: rgba(255, 255, 255, 0.92);
+        --panel-border: rgba(15, 23, 42, 0.12);
+        --text-primary: #111827;
+        --text-muted: #6b7280;
       }
       body {
         margin: 0;
-        background: radial-gradient(circle at center, #10131a, #050608 60%);
+        background: #ffffff;
         font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-        color: #f5f7fa;
+        color: var(--text-primary);
       }
       .game-wrapper {
         position: relative;
@@ -25,46 +31,221 @@
       canvas#game-canvas {
         width: min(1600px, 100vw);
         height: min(900px, 100vh);
-        border: 2px solid rgba(255, 255, 255, 0.2);
-        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
-        background: #0c0f17;
+        border: 3px solid rgba(15, 23, 42, 0.08);
+        border-radius: 20px;
+        box-shadow: 0 30px 80px rgba(15, 23, 42, 0.18);
+        background: #ffffff;
       }
       #ui-overlay {
         position: absolute;
         inset: 0;
         pointer-events: none;
-        display: flex;
-        align-items: flex-start;
-        justify-content: space-between;
-        padding: 16px 24px;
+        display: grid;
+        grid-template-columns: 1fr;
+        grid-template-rows: auto 1fr;
+        padding: 24px;
         box-sizing: border-box;
       }
       .hud {
-        display: grid;
-        gap: 8px;
-        padding: 12px 16px;
-        background: rgba(8, 12, 20, 0.75);
-        border: 1px solid rgba(255, 255, 255, 0.12);
-        border-radius: 12px;
-        min-width: 220px;
+        display: flex;
+        gap: 16px;
+        padding: 16px 20px;
+        background: var(--panel-bg);
+        border: 1px solid var(--panel-border);
+        border-radius: 16px;
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.14);
         pointer-events: none;
-        backdrop-filter: blur(6px);
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+        align-items: center;
       }
-      .hud__health,
-      .hud__fuel,
-      .hud__cooldown {
-        font-size: 15px;
+      .hud--top {
+        justify-content: space-between;
+        font-size: 18px;
+        font-weight: 600;
         letter-spacing: 0.4px;
       }
-      .hud__health {
-        color: #6dff9c;
+      .hud--bottom {
+        margin-top: auto;
+        flex-wrap: wrap;
+        gap: 12px 18px;
       }
-      .hud__fuel {
-        color: #73d8ff;
+      .hud__timer {
+        font-variant-numeric: tabular-nums;
+        color: var(--text-muted);
+      }
+      .hud__scores {
+        display: flex;
+        gap: 12px;
+      }
+      .hud__score {
+        font-weight: 700;
+      }
+      .hud__score--p1 {
+        color: var(--p1);
+      }
+      .hud__score--p2 {
+        color: var(--p2);
+      }
+      .hud__bar {
+        min-width: 200px;
+        display: grid;
+        gap: 6px;
+      }
+      .hud__bar-label {
+        font-size: 13px;
+        letter-spacing: 0.4px;
+        text-transform: uppercase;
+        color: var(--text-muted);
+      }
+      .hud__bar-meter {
+        position: relative;
+        width: 100%;
+        height: 12px;
+        border-radius: 999px;
+        background: rgba(148, 163, 184, 0.2);
+        overflow: hidden;
+      }
+      .hud__bar-fill {
+        position: absolute;
+        inset: 0;
+        width: 50%;
+        border-radius: inherit;
+        background: linear-gradient(90deg, var(--p1), #22d3ee);
+        transition: width 0.2s ease;
+      }
+      .hud__bar-fill::after {
+        content: attr(data-value);
+        position: absolute;
+        right: 8px;
+        top: 50%;
+        transform: translateY(-50%);
+        font-size: 11px;
+        color: #0f172a;
+        font-weight: 600;
+      }
+      .hud__bar:nth-of-type(2) .hud__bar-fill {
+        background: linear-gradient(90deg, #60a5fa, #38bdf8);
       }
       .hud__cooldown {
-        color: #ffc36d;
+        font-size: 14px;
+        color: var(--text-muted);
+      }
+      .hud__ghosts {
+        font-size: 14px;
+        color: var(--text-muted);
+      }
+      .selection-overlay {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(255, 255, 255, 0.85);
+        backdrop-filter: blur(8px);
+        transition: opacity 0.2s ease;
+      }
+      .selection-overlay.hidden {
+        opacity: 0;
+        pointer-events: none !important;
+      }
+      .selection-panel {
+        background: #ffffff;
+        border-radius: 20px;
+        border: 1px solid rgba(15, 23, 42, 0.1);
+        padding: 28px 32px;
+        max-width: 640px;
+        box-shadow: 0 24px 60px rgba(15, 23, 42, 0.22);
+        pointer-events: auto;
+      }
+      .selection-panel h2 {
+        margin: 0 0 24px;
+        font-size: 26px;
+        text-align: center;
+        color: var(--text-primary);
+      }
+      .selection-grid {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      }
+      .selection-card {
+        border: 1px solid rgba(15, 23, 42, 0.12);
+        border-radius: 16px;
+        padding: 16px;
+        background: #f8fafc;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        text-align: left;
+      }
+      .selection-card:hover:not(.disabled) {
+        transform: translateY(-4px);
+        box-shadow: 0 16px 30px rgba(15, 23, 42, 0.18);
+      }
+      .selection-card.disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+      .selection-card h3 {
+        margin: 0 0 12px;
+        font-size: 18px;
+        letter-spacing: 1px;
+      }
+      .selection-card ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 6px;
+        font-size: 14px;
+        color: var(--text-muted);
+      }
+      .countdown {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 120px;
+        font-weight: 700;
+        color: rgba(15, 23, 42, 0.2);
+        pointer-events: none;
+        transition: opacity 0.2s ease;
+      }
+      .countdown.hidden {
+        opacity: 0;
+      }
+      .victory {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(255, 255, 255, 0.95);
+        backdrop-filter: blur(10px);
+      }
+      .victory.hidden {
+        display: none;
+      }
+      .victory__panel {
+        padding: 32px 48px;
+        border-radius: 24px;
+        background: #ffffff;
+        border: 1px solid rgba(15, 23, 42, 0.12);
+        box-shadow: 0 30px 70px rgba(15, 23, 42, 0.2);
+        text-align: center;
+      }
+      .victory__panel h1 {
+        margin: 0 0 12px;
+        font-size: 36px;
+      }
+      .victory__scores {
+        display: flex;
+        justify-content: center;
+        gap: 24px;
+        font-size: 20px;
+        margin: 16px 0;
+      }
+      .victory__hint {
+        color: var(--text-muted);
       }
     </style>
   </head>

--- a/src/core/GameManager.js
+++ b/src/core/GameManager.js
@@ -1,30 +1,49 @@
 import { InputManager } from './InputManager.js';
 import { LevelGenerator } from '../systems/LevelGenerator.js';
 import { PhysicsSystem } from '../systems/PhysicsSystem.js';
-import { Player } from '../entities/Player.js';
-import { Projectile } from '../entities/Projectile.js';
+import { Player, listCharacterTypes } from '../entities/Player.js';
+import {
+  RangerShot,
+  WizardBomb,
+  WarriorSlash,
+  createProjectileFromRecord
+} from '../entities/Projectile.js';
+import { Ghost } from '../entities/Ghost.js';
 import { AssetLoader } from '../rendering/AssetLoader.js';
 import { LevelRenderer } from '../rendering/LevelRenderer.js';
 import { PlayerRenderer } from '../rendering/PlayerRenderer.js';
 import { ProjectileRenderer } from '../rendering/ProjectileRenderer.js';
 import { UIRenderer } from '../rendering/UIRenderer.js';
+import { ParticleSystem } from '../rendering/ParticleSystem.js';
+import { RecordingSession } from './RecordingSession.js';
 
 const FIXED_TIMESTEP = 1 / 60;
+const TURN_DURATION = 60;
+const TOTAL_ROUNDS = 3;
+const CAMERA_WIDTH = 1600;
+
+const PLAYER_META = {
+  1: { tint: 0x45ff9a, label: 'Player 1' },
+  2: { tint: 0xff4f64, label: 'Player 2' }
+};
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
 
 export class GameManager {
   constructor({ canvas, uiRoot }) {
     this.canvas = canvas;
     this.uiRoot = uiRoot;
-    this.renderer = new THREE.WebGLRenderer({ canvas, antialias: false });
+    this.renderer = new THREE.WebGLRenderer({ canvas, antialias: false, alpha: true });
     this.renderer.setSize(canvas.width, canvas.height);
     this.scene = new THREE.Scene();
 
     const aspect = canvas.width / canvas.height;
-    const width = 1600;
-    const height = width / aspect;
-    this.camera = new THREE.OrthographicCamera(0, width, height, 0, -1000, 1000);
-    this.camera.position.set(width / 2, height / 2, 10);
-    this.camera.lookAt(width / 2, height / 2, 0);
+    const height = CAMERA_WIDTH / aspect;
+    this.camera = new THREE.OrthographicCamera(0, CAMERA_WIDTH, height, 0, -1000, 1000);
+    this.camera.position.set(CAMERA_WIDTH / 2, height / 2, 10);
+    this.camera.lookAt(CAMERA_WIDTH / 2, height / 2, 0);
 
     this.clock = new THREE.Clock();
     this.accumulator = 0;
@@ -34,12 +53,39 @@ export class GameManager {
     this.playerRenderer = new PlayerRenderer(this.scene, this.assetLoader);
     this.projectileRenderer = new ProjectileRenderer(this.scene);
     this.uiRenderer = new UIRenderer(uiRoot);
+    this.particles = new ParticleSystem(this.scene);
 
-    this.projectiles = [];
-    this.player = null;
-    this.physics = null;
     this.input = new InputManager(canvas);
     this.mouseVector = new THREE.Vector3();
+
+    this.projectiles = [];
+    this.ghosts = [];
+    this.currentPlayer = null;
+    this.physics = null;
+    this.recordingSession = null;
+    this.turnElapsed = 0;
+    this.stage = 'loading';
+
+    this.state = {
+      round: 1,
+      turnIndex: 0
+    };
+    this.selections = {
+      1: [],
+      2: []
+    };
+    this.recordings = {
+      1: [],
+      2: []
+    };
+    this.scores = {
+      player1: 0,
+      player2: 0
+    };
+    this.finalHealth = {
+      1: 0,
+      2: 0
+    };
 
     this._loadAssets().then(() => {
       this._initGame();
@@ -48,12 +94,17 @@ export class GameManager {
   }
 
   async _loadAssets() {
-    const loads = [
-      this.assetLoader.loadTexture('ranger-idle', 'assets/player1ranger.png').catch(() => null),
-      this.assetLoader.loadTexture('wizard-idle', 'assets/player1wizard.png').catch(() => null),
-      this.assetLoader.loadTexture('warrior-idle', 'assets/player1warrior.png').catch(() => null),
-      this.assetLoader.loadTexture('landblock', 'assets/landblock.png').catch(() => null)
-    ];
+    const characters = ['warrior', 'wizard', 'ranger'];
+    const loads = [];
+    characters.forEach((char) => {
+      loads.push(
+        this.assetLoader.loadTexture(`player1-${char}-idle`, `assets/player1${char}.png`).catch(() => null),
+        this.assetLoader.loadTexture(`player1-${char}-shoot`, `assets/player1${char}shoot.png`).catch(() => null),
+        this.assetLoader.loadTexture(`player2-${char}-idle`, `assets/player2${char}.png`).catch(() => null),
+        this.assetLoader.loadTexture(`player2-${char}-shoot`, `assets/player2${char}shoot.png`).catch(() => null)
+      );
+    });
+    loads.push(this.assetLoader.loadTexture('landblock', 'assets/landblock.png').catch(() => null));
 
     await Promise.all(loads);
     const blockTexture = this.assetLoader.get('landblock');
@@ -67,9 +118,8 @@ export class GameManager {
     this.level = generator.generate();
     this.physics = new PhysicsSystem(this.level);
     this.levelRenderer.renderLevel(this.level);
-    const spawn = this.level.spawnPoints[0];
-    this.player = new Player({ x: spawn.x, y: spawn.y, character: 'ranger' });
-    this.playerRenderer.createSpriteFor(this.player);
+    this.stage = 'selection';
+    this._promptSelection();
   }
 
   _loop() {
@@ -82,25 +132,316 @@ export class GameManager {
       this.accumulator -= FIXED_TIMESTEP;
     }
 
+    this.particles.update(delta);
     this._render();
   }
 
   _step(deltaSeconds) {
-    const inputState = this.input.getState();
-    this._updateMouseWorld(inputState);
-    this.physics.updatePlayer(this.player, inputState, deltaSeconds);
-
-    if (inputState.mouseDown && this.player.canFire()) {
-      this._spawnProjectile(inputState);
-      this.player.triggerCooldown();
+    if (this.stage !== 'playing') {
+      this.uiRenderer.updateHUD({
+        player: this.currentPlayer && this.currentPlayer.isAlive ? this.currentPlayer : null,
+        round: this.state.round,
+        totalRounds: TOTAL_ROUNDS,
+        timerSeconds: TURN_DURATION - this.turnElapsed,
+        activePlayer: this.currentPlayer ? PLAYER_META[this.currentPlayer.playerId].label : '—',
+        scores: this.scores,
+        ghosts: this.ghosts.filter((g) => g.isAlive).length
+      });
+      return;
     }
 
-    this.projectiles = this.projectiles.filter((proj) => proj.isAlive);
-    this.projectiles.forEach((projectile) => {
-      this.physics.updateProjectile(projectile, deltaSeconds);
+    this.turnElapsed += deltaSeconds;
+
+    const inputState = this.input.getState();
+    this._updateMouseWorld(inputState);
+
+    const fired = this._handleAttack(this.currentPlayer, inputState);
+    this.physics.updatePlayer(this.currentPlayer, inputState, deltaSeconds);
+
+    if (fired) {
+      this.currentPlayer.triggerCooldown();
+      this.currentPlayer.triggerShootAnimation();
+    }
+
+    this.recordingSession.captureFrame({
+      time: this.turnElapsed,
+      input: inputState,
+      player: this.currentPlayer,
+      fireEvent: fired
     });
 
-    this.uiRenderer.update(this.player);
+    this._updateGhosts(deltaSeconds);
+    const activeActors = [this.currentPlayer, ...this.ghosts.filter((ghost) => ghost.isAlive)];
+    this.physics.resolveActorCollisions(activeActors);
+
+    this._updateProjectiles(deltaSeconds);
+    this._handleProjectileCollisions();
+    this._cleanupEntities();
+
+    const timerRemaining = clamp(TURN_DURATION - this.turnElapsed, 0, TURN_DURATION);
+    this.uiRenderer.updateHUD({
+      player: this.currentPlayer.isAlive ? this.currentPlayer : null,
+      round: this.state.round,
+      totalRounds: TOTAL_ROUNDS,
+      timerSeconds: timerRemaining,
+      activePlayer: PLAYER_META[this.currentPlayer.playerId].label,
+      scores: this.scores,
+      ghosts: this.ghosts.filter((g) => g.isAlive).length
+    });
+
+    if (this.turnElapsed >= TURN_DURATION || !this.currentPlayer.isAlive) {
+      this._endTurn();
+    }
+  }
+
+  _updateGhosts(deltaSeconds) {
+    this.ghosts.forEach((ghost) => {
+      const frame = ghost.step(deltaSeconds, this.physics);
+      if (!frame) return;
+      const pending = ghost.collectPendingProjectiles();
+      pending.forEach((record) => {
+        const projectile = createProjectileFromRecord(record, ghost.playerId);
+        projectile.ownerId = ghost.playerId;
+        if (projectile.type === 'warrior-slash') {
+          projectile.hitTargets = new Set();
+        }
+        this.projectiles.push(projectile);
+        this._attachParticles(projectile);
+      });
+    });
+  }
+
+  _updateProjectiles(deltaSeconds) {
+    this.projectiles.forEach((projectile) => {
+      if (!projectile.isAlive) return;
+      this.physics.updateProjectile(projectile, deltaSeconds);
+      if (projectile.type === 'wizard-bomb' && projectile.shouldExplode) {
+        this._explodeBomb(projectile);
+      }
+    });
+  }
+
+  _handleProjectileCollisions() {
+    const actors = [this.currentPlayer, ...this.ghosts];
+    this.projectiles.forEach((projectile) => {
+      if (!projectile.isAlive) return;
+      if (projectile.type === 'wizard-bomb') {
+        const hit = actors.find((actor) => this._projectileHitsActor(projectile, actor));
+        if (hit) {
+          projectile.shouldExplode = true;
+          projectile.isAlive = false;
+          this._explodeBomb(projectile);
+        }
+        return;
+      }
+
+      actors.forEach((actor) => {
+        if (!actor.isAlive || actor.playerId === projectile.ownerId) return;
+        if (projectile.type === 'warrior-slash') {
+          projectile.hitTargets = projectile.hitTargets || new Set();
+          if (projectile.hitTargets.has(actor)) return;
+          if (this._slashHits(projectile, actor)) {
+            projectile.hitTargets.add(actor);
+            this._applyDamage(actor, projectile.damage, projectile.ownerId);
+          }
+        } else if (this._projectileHitsActor(projectile, actor)) {
+          this._applyDamage(actor, projectile.damage, projectile.ownerId);
+          projectile.isAlive = false;
+        }
+      });
+    });
+  }
+
+  _cleanupEntities() {
+    this.projectiles = this.projectiles.filter((projectile) => projectile.isAlive);
+
+    this.ghosts = this.ghosts.filter((ghost) => {
+      if (!ghost.isAlive) {
+        this.playerRenderer.remove(ghost);
+        return false;
+      }
+      return true;
+    });
+  }
+
+  _projectileHitsActor(projectile, actor) {
+    if (!actor.isAlive) return false;
+    const dx = actor.position.x - projectile.position.x;
+    const dy = actor.position.y - projectile.position.y;
+    const distance = Math.hypot(dx, dy);
+    const radius = projectile.radius + Math.max(actor.width, actor.height) * 0.3;
+    return distance <= radius;
+  }
+
+  _slashHits(projectile, actor) {
+    const halfW = projectile.width / 2;
+    const halfH = projectile.height / 2;
+    const left = projectile.position.x - halfW;
+    const right = projectile.position.x + halfW;
+    const top = projectile.position.y - halfH;
+    const bottom = projectile.position.y + halfH;
+    const bounds = actor.bounds;
+    return !(bounds.left > right || bounds.right < left || bounds.top > bottom || bounds.bottom < top);
+  }
+
+  _explodeBomb(projectile) {
+    if (projectile.exploded) return;
+    projectile.exploded = true;
+    this.particles.spawnBurst({
+      position: projectile.position,
+      color: projectile.ownerId === 1 ? 0x3cffaa : 0xff6b7d,
+      count: 36,
+      speed: 520,
+      size: 32,
+      lifetime: 1.2
+    });
+
+    const actors = [this.currentPlayer, ...this.ghosts];
+    actors.forEach((actor) => {
+      if (!actor.isAlive || actor.playerId === projectile.ownerId) return;
+      const distance = Math.hypot(actor.position.x - projectile.position.x, actor.position.y - projectile.position.y);
+      if (distance <= projectile.splashRadius) {
+        const ratio = clamp(distance / projectile.splashRadius, 0, 1);
+        const damage = THREE.MathUtils.lerp(projectile.damage, projectile.damageOuter, ratio);
+        this._applyDamage(actor, damage, projectile.ownerId);
+      }
+    });
+  }
+
+  _applyDamage(target, amount, sourcePlayerId) {
+    const result = target.takeDamage(amount, { sourcePlayerId });
+    if (result && result.killed) {
+      this._registerKill(target, sourcePlayerId);
+    }
+  }
+
+  _registerKill(target, killerId) {
+    if (killerId) {
+      const key = killerId === 1 ? 'player1' : 'player2';
+      this.scores[key] += 1;
+    }
+    if (target === this.currentPlayer) {
+      this.finalHealth[target.playerId] = 0;
+    }
+  }
+
+  _handleAttack(player, input) {
+    if (!player.isAlive) return false;
+    if (!player.canFire() || !input.mouseDown) return false;
+
+    const aim = this._aimDirection(player, input);
+    const spawn = {
+      x: player.position.x + aim.x * (player.width / 2),
+      y: player.position.y + aim.y * (player.height / 2)
+    };
+
+    switch (player.character) {
+      case 'ranger': {
+        const stats = player.stats.shot;
+        const shot = new RangerShot({
+          x: spawn.x,
+          y: spawn.y,
+          direction: aim,
+          ownerId: player.playerId,
+          damage: stats.damage,
+          speed: stats.speed
+        });
+        this.projectiles.push(shot);
+        this._attachParticles(shot);
+        this.recordingSession.recordProjectile({
+          type: 'ranger-shot',
+          position: { x: shot.position.x, y: shot.position.y },
+          direction: aim,
+          speed: stats.speed,
+          damage: stats.damage
+        });
+        return true;
+      }
+      case 'wizard': {
+        const stats = player.stats.bomb;
+        const direction = this._lobDirection(aim);
+        const bomb = new WizardBomb({
+          x: spawn.x,
+          y: spawn.y,
+          direction,
+          speed: stats.projectileSpeed,
+          ownerId: player.playerId,
+          stats
+        });
+        this.projectiles.push(bomb);
+        this._attachParticles(bomb);
+        this.recordingSession.recordProjectile({
+          type: 'wizard-bomb',
+          position: { x: bomb.position.x, y: bomb.position.y },
+          direction,
+          speed: stats.projectileSpeed,
+          damage: stats.damageCenter,
+          damageOuter: stats.damageOuter,
+          splashRadius: stats.splashRadius,
+          fuse: stats.fuse,
+          gravity: stats.gravity
+        });
+        return true;
+      }
+      case 'warrior': {
+        const stats = player.stats;
+        const slash = new WarriorSlash({
+          origin: player.position,
+          direction: aim,
+          stats,
+          ownerId: player.playerId
+        });
+        slash.hitTargets = new Set();
+        this.projectiles.push(slash);
+        this.recordingSession.recordProjectile({
+          type: 'warrior-slash',
+          origin: { x: player.position.x, y: player.position.y },
+          direction: aim,
+          damage: stats.melee.damage,
+          width: stats.melee.width,
+          height: stats.melee.height,
+          lifetime: stats.melee.lifetime
+        });
+        this.particles.spawnBurst({
+          position: player.position,
+          color: player.playerId === 1 ? 0x5cff9b : 0xff6b6b,
+          count: 18,
+          speed: 260,
+          size: 24,
+          lifetime: 0.4
+        });
+        return true;
+      }
+      default:
+        return false;
+    }
+  }
+
+  _attachParticles(projectile) {
+    const tint = projectile.ownerId === 1 ? 0x5cff9b : 0xff6b6b;
+    this.particles.attachProjectile(projectile, {
+      color: tint,
+      rate: projectile.type === 'ranger-shot' ? 1 / 120 : 1 / 40,
+      size: projectile.type === 'wizard-bomb' ? 26 : 16,
+      speed: projectile.type === 'wizard-bomb' ? 320 : 180
+    });
+  }
+
+  _aimDirection(player, input) {
+    const dx = (input.mouseWorldX ?? player.position.x) - player.position.x;
+    const dy = (input.mouseWorldY ?? player.position.y) - player.position.y;
+    const length = Math.hypot(dx, dy) || 1;
+    const dir = { x: dx / length, y: dy / length };
+    player.updateFacing(input.mouseWorldX ?? player.position.x);
+    return dir;
+  }
+
+  _lobDirection(direction) {
+    const adjusted = { x: direction.x, y: direction.y - 0.25 };
+    const length = Math.hypot(adjusted.x, adjusted.y) || 1;
+    adjusted.x /= length;
+    adjusted.y /= length;
+    return adjusted;
   }
 
   _updateMouseWorld(inputState) {
@@ -113,27 +454,167 @@ export class GameManager {
     inputState.mouseWorldY = this.mouseVector.y;
   }
 
-  _spawnProjectile(inputState) {
-    const origin = { x: this.player.position.x, y: this.player.position.y };
-    const dx = inputState.mouseWorldX - origin.x;
-    const dy = inputState.mouseWorldY - origin.y;
-    const length = Math.hypot(dx, dy) || 1;
-    const dirX = dx / length;
-    const dirY = dy / length;
-    const speed = this.player.stats.projectileSpeed;
-    const projectile = new Projectile({
-      x: origin.x + dirX * (this.player.width / 2),
-      y: origin.y + dirY * (this.player.height / 2),
-      velocity: { x: dirX * speed, y: dirY * speed },
-      lifetime: 3,
-      radius: 8
-    });
-    this.projectiles.push(projectile);
-  }
-
   _render() {
-    this.playerRenderer.update(this.player);
+    if (this.currentPlayer) {
+      this.playerRenderer.update(this.currentPlayer);
+    }
+    this.ghosts.forEach((ghost) => this.playerRenderer.update(ghost));
     this.projectileRenderer.sync(this.projectiles);
     this.renderer.render(this.scene, this.camera);
+  }
+
+  _promptSelection() {
+    const playerId = this._activePlayerId();
+    const available = this._availableCharacters(playerId);
+    const used = this.selections[playerId];
+    this.uiRenderer.showCharacterSelection({
+      playerId,
+      available,
+      used,
+      onSelect: (character) => this._startCountdown(playerId, character)
+    });
+  }
+
+  _startCountdown(playerId, character) {
+    let count = 3;
+    this.stage = 'countdown';
+    this.uiRenderer.showCountdown(count);
+    const interval = setInterval(() => {
+      count -= 1;
+      if (count <= 0) {
+        clearInterval(interval);
+        this.uiRenderer.showCountdown('GO!');
+        setTimeout(() => {
+          this.uiRenderer.hideCountdown();
+          this._beginTurn(playerId, character);
+        }, 450);
+      } else {
+        this.uiRenderer.showCountdown(count);
+      }
+    }, 650);
+  }
+
+  _beginTurn(playerId, character) {
+    const roundIndex = this.state.round - 1;
+    this.selections[playerId][roundIndex] = character;
+    const spawn = this.level.spawnPoints.find((point) => point.playerId === playerId) ?? {
+      x: playerId === 1 ? 200 : CAMERA_WIDTH - 200,
+      y: 680
+    };
+
+    this.currentPlayer = new Player({
+      x: spawn.x,
+      y: spawn.y,
+      character,
+      playerId,
+      tint: PLAYER_META[playerId].tint
+    });
+    this.playerRenderer.createSpriteFor(this.currentPlayer);
+    this.turnElapsed = 0;
+    this.recordingSession = new RecordingSession({
+      playerId,
+      character,
+      round: this.state.round
+    });
+
+    this.projectiles = [];
+    this.particles.clear();
+    this._spawnGhostsForTurn(playerId);
+    this.stage = 'playing';
+  }
+
+  _spawnGhostsForTurn(playerId) {
+    this.ghosts.forEach((ghost) => this.playerRenderer.remove(ghost));
+    this.ghosts = [];
+
+    const shouldSpawn = (recording) => {
+      if (recording.round < this.state.round) return true;
+      if (recording.round === this.state.round && recording.playerId !== playerId) return true;
+      return false;
+    };
+
+    const allRecordings = [...this.recordings[1], ...this.recordings[2]];
+    allRecordings
+      .filter(shouldSpawn)
+      .forEach((recording) => {
+        const tint = PLAYER_META[recording.playerId].tint;
+        const ghost = new Ghost({ recording, tint });
+        this.ghosts.push(ghost);
+        this.playerRenderer.createSpriteFor(ghost);
+      });
+  }
+
+  _endTurn() {
+    if (this.stage !== 'playing') return;
+    this.stage = 'transition';
+
+    const deathFrameIndex = this.currentPlayer.isAlive
+      ? null
+      : Math.floor(this.turnElapsed / FIXED_TIMESTEP);
+    this.finalHealth[this.currentPlayer.playerId] = Math.max(0, this.currentPlayer.health);
+
+    const recording = this.recordingSession.finish({
+      deathFrameIndex,
+      totalTime: this.turnElapsed
+    });
+    this.recordings[this.currentPlayer.playerId].push(recording);
+
+    this.playerRenderer.remove(this.currentPlayer);
+    this.currentPlayer = null;
+    this.ghosts.forEach((ghost) => this.playerRenderer.remove(ghost));
+    this.ghosts = [];
+    this.projectiles = [];
+    this.particles.clear();
+
+    this._advanceTurn();
+  }
+
+  _advanceTurn() {
+    if (this.state.turnIndex === 0) {
+      this.state.turnIndex = 1;
+    } else {
+      this.state.turnIndex = 0;
+      if (this.state.round < TOTAL_ROUNDS) {
+        this.state.round += 1;
+      } else {
+        this._endGame();
+        return;
+      }
+    }
+    this.stage = 'selection';
+    this._promptSelection();
+  }
+
+  _endGame() {
+    const { player1, player2 } = this.scores;
+    let winner;
+    let detail = `Final score ${player1} - ${player2}`;
+    if (player1 > player2) {
+      winner = 'Player 1 wins the time war!';
+    } else if (player2 > player1) {
+      winner = 'Player 2 rewrites history!';
+    } else {
+      if (this.finalHealth[1] > this.finalHealth[2]) {
+        winner = 'Player 1 survives the paradox!';
+        detail += ' — Tiebreaker: remaining health';
+      } else if (this.finalHealth[2] > this.finalHealth[1]) {
+        winner = 'Player 2 survives the paradox!';
+        detail += ' — Tiebreaker: remaining health';
+      } else {
+        winner = 'It’s a stalemate in spacetime!';
+        detail += ' — Perfect tie';
+      }
+    }
+    this.uiRenderer.showVictory({ winner, scores: this.scores, detail });
+    this.stage = 'gameover';
+  }
+
+  _activePlayerId() {
+    return this.state.turnIndex === 0 ? 1 : 2;
+  }
+
+  _availableCharacters(playerId) {
+    const used = this.selections[playerId];
+    return listCharacterTypes().filter((character) => !used.includes(character));
   }
 }

--- a/src/core/RecordingSession.js
+++ b/src/core/RecordingSession.js
@@ -1,0 +1,63 @@
+export class RecordingSession {
+  constructor({ playerId, character, round }) {
+    this.playerId = playerId;
+    this.character = character;
+    this.round = round;
+    this.frames = [];
+    this.projectiles = [];
+    this.duration = 0;
+    this._frameIndex = 0;
+  }
+
+  captureFrame({
+    time,
+    input,
+    player,
+    fireEvent = false
+  }) {
+    this.frames.push({
+      index: this._frameIndex,
+      time,
+      input: {
+        w: !!input.w,
+        a: !!input.a,
+        s: !!input.s,
+        d: !!input.d,
+        mouseDown: !!input.mouseDown,
+        mouseWorldX: input.mouseWorldX ?? player.position.x,
+        mouseWorldY: input.mouseWorldY ?? player.position.y
+      },
+      fireEvent,
+      state: {
+        position: { x: player.position.x, y: player.position.y },
+        velocity: { x: player.velocity.x, y: player.velocity.y },
+        health: player.health,
+        jetpackFuel: player.jetpackFuel,
+        facing: player.facingDirection
+      }
+    });
+
+    this._frameIndex += 1;
+    this.duration = time;
+  }
+
+  recordProjectile(event) {
+    this.projectiles.push({
+      ...event,
+      frameIndex: Math.max(0, this._frameIndex)
+    });
+  }
+
+  finish({ deathFrameIndex = null, totalTime }) {
+    this.duration = totalTime ?? this.duration;
+    return {
+      playerId: this.playerId,
+      character: this.character,
+      round: this.round,
+      frames: this.frames,
+      projectiles: this.projectiles,
+      duration: this.duration,
+      deathFrameIndex
+    };
+  }
+}

--- a/src/entities/Ghost.js
+++ b/src/entities/Ghost.js
@@ -1,0 +1,68 @@
+import { Player } from './Player.js';
+
+const FIXED_TIMESTEP = 1 / 60;
+
+export class Ghost extends Player {
+  constructor({ recording, tint }) {
+    const firstFrame = recording.frames[0];
+    super({
+      x: firstFrame?.state?.position?.x ?? 0,
+      y: firstFrame?.state?.position?.y ?? 0,
+      character: recording.character,
+      playerId: recording.playerId,
+      tint,
+      isGhost: true
+    });
+    this.recording = recording;
+    this.elapsed = 0;
+    this.frameIndex = 0;
+    this.finished = false;
+    this.nextProjectileIndex = 0;
+  }
+
+  step(deltaSeconds, physicsSystem) {
+    if (!this.isAlive || this.finished) return null;
+
+    this.elapsed += deltaSeconds;
+    const frame = this._getFrameForElapsed();
+    if (!frame) {
+      this.finished = true;
+      return null;
+    }
+
+    if (this.recording.deathFrameIndex !== null && this.frameIndex >= this.recording.deathFrameIndex) {
+      this.isAlive = false;
+      this.finished = true;
+      return null;
+    }
+
+    physicsSystem.updatePlayer(this, frame.input, deltaSeconds);
+    this.facingDirection = frame.state.facing;
+    return frame;
+  }
+
+  collectPendingProjectiles() {
+    if (!this.isAlive) return [];
+    const ready = [];
+    while (this.nextProjectileIndex < this.recording.projectiles.length) {
+      const projectileRecord = this.recording.projectiles[this.nextProjectileIndex];
+      if (projectileRecord.frameIndex <= this.frameIndex) {
+        ready.push(projectileRecord);
+        this.nextProjectileIndex += 1;
+      } else {
+        break;
+      }
+    }
+    return ready;
+  }
+
+  _getFrameForElapsed() {
+    if (!this.recording.frames.length) return null;
+    const frameIdx = Math.min(
+      Math.floor(this.elapsed / FIXED_TIMESTEP),
+      this.recording.frames.length - 1
+    );
+    this.frameIndex = frameIdx;
+    return this.recording.frames[frameIdx];
+  }
+}

--- a/src/entities/Projectile.js
+++ b/src/entities/Projectile.js
@@ -1,23 +1,160 @@
 import { Entity } from './Entity.js';
 
 export class Projectile extends Entity {
-  constructor({ x, y, velocity, lifetime = 2, speed = 400, radius = 8, ownerId = 0 }) {
+  constructor({
+    x,
+    y,
+    radius = 8,
+    velocity = { x: 0, y: 0 },
+    lifetime = 3,
+    ownerId,
+    damage = 0,
+    type = 'generic'
+  }) {
     super({ x, y, width: radius * 2, height: radius * 2 });
     this.velocity = { ...velocity };
     this.lifetime = lifetime;
-    this.remainingLife = lifetime;
-    this.speed = speed;
+    this.age = 0;
     this.ownerId = ownerId;
     this.radius = radius;
-    this.damage = 20;
+    this.damage = damage;
+    this.type = type;
+    this.maxDistance = Infinity;
+    this.startPosition = { x, y };
+    this.color = 0xffffff;
   }
 
   update(deltaSeconds) {
+    if (!this.isAlive) return;
+    this.age += deltaSeconds;
     this.position.x += this.velocity.x * deltaSeconds;
     this.position.y += this.velocity.y * deltaSeconds;
-    this.remainingLife -= deltaSeconds;
-    if (this.remainingLife <= 0) {
+    if (this.age >= this.lifetime) {
       this.isAlive = false;
     }
+    const traveled = Math.hypot(
+      this.position.x - this.startPosition.x,
+      this.position.y - this.startPosition.y
+    );
+    if (traveled > this.maxDistance) {
+      this.isAlive = false;
+    }
+  }
+}
+
+export class RangerShot extends Projectile {
+  constructor({ x, y, direction, ownerId, damage = 40, speed = 720 }) {
+    super({
+      x,
+      y,
+      radius: 10,
+      velocity: { x: direction.x * speed, y: direction.y * speed },
+      lifetime: 2.2,
+      ownerId,
+      damage,
+      type: 'ranger-shot'
+    });
+    this.maxDistance = 900;
+    this.color = 0x55ff99;
+  }
+}
+
+export class WarriorSlash extends Projectile {
+  constructor({ origin, direction, stats, ownerId }) {
+    const width = stats.melee.width;
+    const height = stats.melee.height;
+    const offsetX = direction.x * (width / 2 + 16);
+    const offsetY = direction.y * (height / 2);
+    super({
+      x: origin.x + offsetX,
+      y: origin.y + offsetY,
+      radius: Math.max(width, height) / 2,
+      velocity: { x: 0, y: 0 },
+      lifetime: stats.melee.lifetime,
+      ownerId,
+      damage: stats.melee.damage,
+      type: 'warrior-slash'
+    });
+    this.width = width;
+    this.height = height;
+    this.color = 0xffa64d;
+    this.facingAngle = Math.atan2(direction.y, direction.x);
+  }
+}
+
+export class WizardBomb extends Projectile {
+  constructor({ x, y, direction, speed, ownerId, stats }) {
+    super({
+      x,
+      y,
+      radius: 16,
+      velocity: { x: direction.x * speed, y: direction.y * speed },
+      lifetime: stats.fuse,
+      ownerId,
+      damage: stats.damageCenter,
+      type: 'wizard-bomb'
+    });
+    this.gravity = stats.gravity;
+    this.fuse = stats.fuse;
+    this.splashRadius = stats.splashRadius;
+    this.damageOuter = stats.damageOuter;
+    this.color = 0xff5577;
+  }
+
+  update(deltaSeconds) {
+    if (!this.isAlive) return;
+    this.age += deltaSeconds;
+    this.velocity.y += this.gravity * deltaSeconds;
+    this.position.x += this.velocity.x * deltaSeconds;
+    this.position.y += this.velocity.y * deltaSeconds;
+    if (this.age >= this.fuse) {
+      this.isAlive = false;
+      this.shouldExplode = true;
+    }
+  }
+}
+
+export function createProjectileFromRecord(record, ownerId) {
+  switch (record.type) {
+    case 'ranger-shot':
+      return new RangerShot({
+        x: record.position.x,
+        y: record.position.y,
+        direction: record.direction,
+        ownerId,
+        damage: record.damage,
+        speed: record.speed
+      });
+    case 'wizard-bomb':
+      return new WizardBomb({
+        x: record.position.x,
+        y: record.position.y,
+        direction: record.direction,
+        speed: record.speed,
+        ownerId,
+        stats: {
+          damageCenter: record.damage,
+          damageOuter: record.damageOuter,
+          splashRadius: record.splashRadius,
+          fuse: record.fuse,
+          gravity: record.gravity
+        }
+      });
+    case 'warrior-slash':
+      return new WarriorSlash({
+        origin: record.origin,
+        direction: record.direction,
+        stats: {
+          melee: {
+            damage: record.damage,
+            width: record.width,
+            height: record.height,
+            lifetime: record.lifetime
+          }
+        },
+        ownerId
+      });
+    default:
+      return new Projectile({ x: record.position.x, y: record.position.y, ownerId });
   }
 }

--- a/src/rendering/ParticleSystem.js
+++ b/src/rendering/ParticleSystem.js
@@ -1,0 +1,125 @@
+class Particle {
+  constructor(scene, { position, velocity, color, lifetime, size, z = 2, opacity = 1 }) {
+    this.scene = scene;
+    this.position = { ...position };
+    this.velocity = { ...velocity };
+    this.lifetime = lifetime;
+    this.age = 0;
+    this.size = size;
+    this.material = new THREE.SpriteMaterial({
+      color,
+      transparent: true,
+      opacity,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending
+    });
+    this.sprite = new THREE.Sprite(this.material);
+    this.sprite.scale.set(size, size, 1);
+    this.sprite.position.set(position.x, position.y, z);
+    this.scene.add(this.sprite);
+  }
+
+  update(deltaSeconds) {
+    this.age += deltaSeconds;
+    const t = this.age / this.lifetime;
+    this.position.x += this.velocity.x * deltaSeconds;
+    this.position.y += this.velocity.y * deltaSeconds;
+    this.velocity.x *= 0.92;
+    this.velocity.y *= 0.92;
+    this.sprite.position.set(this.position.x, this.position.y, this.sprite.position.z);
+    this.material.opacity = Math.max(0, 1 - t);
+    this.sprite.scale.setScalar(this.size * (1 - t * 0.5));
+    if (this.age >= this.lifetime) {
+      this.dispose();
+      return false;
+    }
+    return true;
+  }
+
+  dispose() {
+    if (this.sprite) {
+      this.scene.remove(this.sprite);
+      this.sprite = null;
+    }
+    if (this.material) {
+      this.material.dispose();
+      this.material = null;
+    }
+  }
+}
+
+export class ParticleSystem {
+  constructor(scene) {
+    this.scene = scene;
+    this.particles = [];
+    this.trails = new Map();
+  }
+
+  spawnBurst({ position, color, count = 20, speed = 320, lifetime = 0.8, size = 22 }) {
+    for (let i = 0; i < count; i += 1) {
+      const angle = Math.random() * Math.PI * 2;
+      const magnitude = Math.random() * speed;
+      const velocity = {
+        x: Math.cos(angle) * magnitude,
+        y: Math.sin(angle) * magnitude
+      };
+      this._spawnParticle({ position, velocity, color, lifetime: lifetime * (0.6 + Math.random() * 0.6), size });
+    }
+  }
+
+  attachProjectile(projectile, { color, rate = 1 / 60, speed = 220, size = 16 } = {}) {
+    this.trails.set(projectile, {
+      projectile,
+      color,
+      rate,
+      speed,
+      size,
+      accumulator: 0
+    });
+  }
+
+  update(deltaSeconds) {
+    this.particles = this.particles.filter((particle) => particle.update(deltaSeconds));
+
+    for (const [projectile, trail] of this.trails) {
+      if (!projectile.isAlive) {
+        this.trails.delete(projectile);
+        continue;
+      }
+      trail.accumulator += deltaSeconds;
+      while (trail.accumulator >= trail.rate) {
+        trail.accumulator -= trail.rate;
+        const angle = Math.random() * Math.PI * 2;
+        const magnitude = Math.random() * trail.speed * 0.4;
+        const velocity = {
+          x: Math.cos(angle) * magnitude,
+          y: Math.sin(angle) * magnitude - Math.random() * 40
+        };
+        this._spawnParticle({
+          position: projectile.position,
+          velocity,
+          color: trail.color,
+          lifetime: 0.5 + Math.random() * 0.4,
+          size: trail.size * (0.4 + Math.random() * 0.6)
+        });
+      }
+    }
+  }
+
+  clear() {
+    this.particles.forEach((particle) => particle.dispose());
+    this.particles = [];
+    this.trails.clear();
+  }
+
+  _spawnParticle({ position, velocity, color, lifetime, size }) {
+    const particle = new Particle(this.scene, {
+      position,
+      velocity,
+      color,
+      lifetime,
+      size
+    });
+    this.particles.push(particle);
+  }
+}

--- a/src/rendering/ProjectileRenderer.js
+++ b/src/rendering/ProjectileRenderer.js
@@ -16,15 +16,47 @@ export class ProjectileRenderer {
     projectiles.forEach((projectile) => {
       if (!projectile.isAlive) return;
       if (!this.projectileMeshes.has(projectile)) {
-        const geometry = new THREE.CircleGeometry(projectile.radius, 12);
-        const material = new THREE.MeshBasicMaterial({ color: 0xffda66 });
-        const mesh = new THREE.Mesh(geometry, material);
-        mesh.position.set(projectile.position.x, projectile.position.y, 1);
+        const mesh = this._createMesh(projectile);
         this.scene.add(mesh);
         this.projectileMeshes.set(projectile, mesh);
       }
       const mesh = this.projectileMeshes.get(projectile);
       mesh.position.set(projectile.position.x, projectile.position.y, 1);
+      if (projectile.type === 'warrior-slash') {
+        mesh.rotation.z = projectile.facingAngle ?? 0;
+      }
     });
+  }
+
+  _createMesh(projectile) {
+    let geometry;
+    let materialColor = projectile.color ?? 0xffffff;
+    switch (projectile.type) {
+      case 'wizard-bomb':
+        geometry = new THREE.CircleGeometry(projectile.radius, 16);
+        break;
+      case 'warrior-slash':
+        geometry = new THREE.PlaneGeometry(projectile.width, projectile.height);
+        materialColor = 0xffb347;
+        break;
+      default:
+        geometry = new THREE.CircleGeometry(projectile.radius, 10);
+    }
+
+    if (projectile.ownerId === 2) {
+      materialColor = 0xff4f64;
+    } else if (projectile.ownerId === 1) {
+      materialColor = 0x45ff9a;
+    }
+
+    const material = new THREE.MeshBasicMaterial({
+      color: materialColor,
+      transparent: true,
+      opacity: projectile.type === 'warrior-slash' ? 0.7 : 1,
+      blending: projectile.type === 'warrior-slash' ? THREE.AdditiveBlending : THREE.NormalBlending
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.set(projectile.position.x, projectile.position.y, 1);
+    return mesh;
   }
 }

--- a/src/rendering/UIRenderer.js
+++ b/src/rendering/UIRenderer.js
@@ -1,29 +1,180 @@
+import { CHARACTER_STATS } from '../entities/Player.js';
+
 export class UIRenderer {
   constructor(rootElement) {
     this.rootElement = rootElement;
     this.rootElement.innerHTML = '';
 
-    this.hud = document.createElement('div');
-    this.hud.className = 'hud';
-    this.rootElement.appendChild(this.hud);
-
-    this.healthEl = document.createElement('div');
-    this.healthEl.className = 'hud__health';
-    this.hud.appendChild(this.healthEl);
-
-    this.fuelEl = document.createElement('div');
-    this.fuelEl.className = 'hud__fuel';
-    this.hud.appendChild(this.fuelEl);
-
-    this.cooldownEl = document.createElement('div');
-    this.cooldownEl.className = 'hud__cooldown';
-    this.hud.appendChild(this.cooldownEl);
+    this._buildHUD();
   }
 
-  update(player) {
-    if (!player) return;
-    this.healthEl.textContent = `Health: ${player.health.toFixed(0)} / ${player.stats.maxHealth}`;
-    this.fuelEl.textContent = `Jetpack Fuel: ${player.jetpackFuel.toFixed(1)}s`;
-    this.cooldownEl.textContent = `Attack Cooldown: ${player.attackCooldown.toFixed(2)}s`;
+  _buildHUD() {
+    this.topBar = document.createElement('div');
+    this.topBar.className = 'hud hud--top';
+    this.roundLabel = document.createElement('div');
+    this.roundLabel.className = 'hud__round';
+    this.timerLabel = document.createElement('div');
+    this.timerLabel.className = 'hud__timer';
+    this.scoreLabel = document.createElement('div');
+    this.scoreLabel.className = 'hud__scores';
+    this.topBar.append(this.roundLabel, this.timerLabel, this.scoreLabel);
+    this.rootElement.appendChild(this.topBar);
+
+    this.bottomPanel = document.createElement('div');
+    this.bottomPanel.className = 'hud hud--bottom';
+    this.healthBar = this._createBar('Health');
+    this.fuelBar = this._createBar('Fuel');
+    this.cooldownText = document.createElement('div');
+    this.cooldownText.className = 'hud__cooldown';
+    this.ghostLabel = document.createElement('div');
+    this.ghostLabel.className = 'hud__ghosts';
+    this.bottomPanel.append(
+      this.healthBar.container,
+      this.fuelBar.container,
+      this.cooldownText,
+      this.ghostLabel
+    );
+    this.rootElement.appendChild(this.bottomPanel);
+
+    this.selectionOverlay = document.createElement('div');
+    this.selectionOverlay.className = 'selection-overlay hidden';
+    this.rootElement.appendChild(this.selectionOverlay);
+
+    this.countdownEl = document.createElement('div');
+    this.countdownEl.className = 'countdown hidden';
+    this.rootElement.appendChild(this.countdownEl);
+
+    this.victoryOverlay = document.createElement('div');
+    this.victoryOverlay.className = 'victory hidden';
+    this.rootElement.appendChild(this.victoryOverlay);
+  }
+
+  _createBar(label) {
+    const container = document.createElement('div');
+    container.className = 'hud__bar';
+    const labelEl = document.createElement('span');
+    labelEl.className = 'hud__bar-label';
+    labelEl.textContent = label;
+    const meter = document.createElement('div');
+    meter.className = 'hud__bar-meter';
+    const fill = document.createElement('div');
+    fill.className = 'hud__bar-fill';
+    meter.appendChild(fill);
+    container.append(labelEl, meter);
+    return { container, fill, label: labelEl };
+  }
+
+  updateHUD({
+    player,
+    round,
+    totalRounds,
+    timerSeconds,
+    activePlayer,
+    scores,
+    ghosts
+  }) {
+    this.roundLabel.textContent = `Round ${round} / ${totalRounds} — ${activePlayer}`;
+    this.timerLabel.textContent = timerSeconds >= 0 ? `${timerSeconds.toFixed(0).padStart(2, '0')}s` : '--';
+    this.scoreLabel.innerHTML = `
+      <span class="hud__score hud__score--p1">P1 ${scores.player1}</span>
+      <span class="hud__score hud__score--p2">P2 ${scores.player2}</span>
+    `;
+
+    if (!player) {
+      this.healthBar.fill.style.width = '0%';
+      this.healthBar.fill.dataset.value = '0';
+      this.fuelBar.fill.style.width = '0%';
+      this.fuelBar.fill.dataset.value = '0';
+      this.cooldownText.textContent = '';
+      this.ghostLabel.textContent = `Ghosts: ${ghosts}`;
+      return;
+    }
+
+    const healthPct = Math.max(0, player.health / player.maxHealth);
+    this.healthBar.fill.style.width = `${healthPct * 100}%`;
+    this.healthBar.fill.dataset.value = `${player.health.toFixed(0)} / ${player.maxHealth}`;
+
+    const fuelPct = Math.max(0, player.jetpackFuel / player.maxJetpackFuel);
+    this.fuelBar.fill.style.width = `${fuelPct * 100}%`;
+    this.fuelBar.fill.dataset.value = `${player.jetpackFuel.toFixed(1)}s`;
+    this.cooldownText.textContent = `Cooldown: ${player.attackCooldown.toFixed(1)}s`;
+    this.ghostLabel.textContent = `Ghosts active: ${ghosts}`;
+  }
+
+  showCharacterSelection({ playerId, available, used, onSelect }) {
+    this.selectionOverlay.innerHTML = '';
+    this.selectionOverlay.classList.remove('hidden');
+    this.selectionOverlay.style.pointerEvents = 'auto';
+
+    const panel = document.createElement('div');
+    panel.className = 'selection-panel';
+    const heading = document.createElement('h2');
+    heading.textContent = `Player ${playerId} — choose your operative`;
+    panel.appendChild(heading);
+
+    const grid = document.createElement('div');
+    grid.className = 'selection-grid';
+
+    Object.entries(CHARACTER_STATS).forEach(([key, stats]) => {
+      const card = document.createElement('button');
+      card.className = 'selection-card';
+      card.disabled = used.includes(key);
+      if (!available.includes(key)) {
+        card.classList.add('disabled');
+        card.disabled = true;
+      }
+      card.innerHTML = `
+        <h3>${key.toUpperCase()}</h3>
+        <ul>
+          <li>HP: ${stats.maxHealth}</li>
+          <li>Speed: ${stats.speed}</li>
+          <li>Cooldown: ${stats.cooldown.toFixed(1)}s</li>
+          <li>Fuel: ${stats.jetpackFuel.toFixed(1)}s</li>
+        </ul>
+      `;
+      if (!card.disabled) {
+        card.addEventListener('click', () => {
+          this.hideSelection();
+          onSelect(key);
+        });
+      }
+      grid.appendChild(card);
+    });
+
+    panel.appendChild(grid);
+    this.selectionOverlay.appendChild(panel);
+  }
+
+  hideSelection() {
+    this.selectionOverlay.classList.add('hidden');
+    this.selectionOverlay.style.pointerEvents = 'none';
+  }
+
+  showCountdown(value) {
+    this.countdownEl.classList.remove('hidden');
+    this.countdownEl.textContent = value;
+  }
+
+  hideCountdown() {
+    this.countdownEl.classList.add('hidden');
+  }
+
+  showVictory({ winner, scores, detail }) {
+    this.victoryOverlay.innerHTML = `
+      <div class="victory__panel">
+        <h1>${winner}</h1>
+        <p>${detail}</p>
+        <div class="victory__scores">
+          <span class="hud__score hud__score--p1">P1 ${scores.player1}</span>
+          <span class="hud__score hud__score--p2">P2 ${scores.player2}</span>
+        </div>
+        <p class="victory__hint">Refresh the page to play again.</p>
+      </div>
+    `;
+    this.victoryOverlay.classList.remove('hidden');
+  }
+
+  clearVictory() {
+    this.victoryOverlay.classList.add('hidden');
   }
 }


### PR DESCRIPTION
## Summary
- implement the complete three-round time-loop flow with input recording, ghost playback, scoring, and hot-seat turn handling
- add character-specific attacks including ranger shots, wizard bombs, warrior slashes, and replay-safe projectile recording with particle effects
- overhaul rendering and UI for selection, HUD, countdowns, and a bright white theme to match the final presentation

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e2f70115108325ba44497df5bcfa2c